### PR TITLE
Batch Insert Bugfix

### DIFF
--- a/__tests__/TestSqlCommonRaw.ml
+++ b/__tests__/TestSqlCommonRaw.ml
@@ -157,7 +157,7 @@ describe "Raw SQL Query Test Sequence" (fun () ->
   );
 
   testAsync "Rollback batch insert on duplicate key" (fun finish ->
-    let id_0 = string_of_int (Js.Math.random_int Js.Int.min Js.Int.max) in
+    let id_0 = string_of_int (Js.Math.random_int 0 (Js.Int.max - 1)) in
     let code_0 = {j|unique-value-$id_0|j} in
     let sql = "INSERT INTO test.simple (id, code) VALUES (?, ?)" in
     let params = `Positional (Json.Encode.array Json.Encode.string [| id_0; code_0 |]) in
@@ -165,14 +165,15 @@ describe "Raw SQL Query Test Sequence" (fun () ->
       match res with
       | `Error e -> let _ = Js.log e in finish (fail "see log")
       | `Mutation (_, _) ->
-        let id_1 = string_of_int (Js.Math.random_int Js.Int.min Js.Int.max) in
+        let id_1 = string_of_int (Js.Math.random_int 0 (Js.Int.max - 1)) in
         let code_1 = {j|unique-value-$id_1|j} in
         let batch_size = 1 in
         let table = "test.simple" in
         let columns = Belt.Array.map [|"id"; "code"|] Json.Encode.string in 
+        (* order is important here *)
         let rows = Belt.Array.map [|
           Json.Encode.array Json.Encode.string [| id_1; code_1 |];
-          Json.Encode.array Json.Encode.string [| id_0; code_0 |]
+          Json.Encode.array Json.Encode.string [| id_0; code_0 |];
         |] (fun a -> a) in
         Sql.mutate_batch conn ~batch_size ~table ~columns ~rows (fun res ->
           match res with

--- a/__tests__/TestUtil.ml
+++ b/__tests__/TestUtil.ml
@@ -1,23 +1,10 @@
 
 let env = Node.Process.process##env
-
-let host = Js.Dict.get env "MYSQL_HOST"
-let _ = Js.Console.log2 "host=" host
-
-let host = Belt.Option.getWithDefault host "localhost"
-let _ = Js.Console.log2 "host=" host
-
+let host = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_HOST") "localhost"
 let port = int_of_string (Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_PORT") "3306")
-let _ = Js.Console.log2 "port=" port
-
 let user = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_USER") "root"
-let _ = Js.Console.log2 "user=" user
-
 let password = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_PASSWORD") "password"
-let _ = Js.Console.log2 "password=" password
-
 let database = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_DATABASE") "database"
-let _ = Js.Console.log2 "database=" database
 
 let connect _ = MySql2.connect
   ~host

--- a/__tests__/TestUtil.ml
+++ b/__tests__/TestUtil.ml
@@ -1,6 +1,28 @@
 
+let env = Node.Process.process##env
+
+let host = Js.Dict.get env "MYSQL_HOST"
+let _ = Js.Console.log2 "host=" host
+
+let host = Belt.Option.getWithDefault host "localhost"
+let _ = Js.Console.log2 "host=" host
+
+let port = int_of_string (Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_PORT") "3306")
+let _ = Js.Console.log2 "port=" port
+
+let user = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_USER") "root"
+let _ = Js.Console.log2 "user=" user
+
+let password = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_PASSWORD") "password"
+let _ = Js.Console.log2 "password=" password
+
+let database = Belt.Option.getWithDefault (Js.Dict.get env "MYSQL_DATABASE") "database"
+let _ = Js.Console.log2 "database=" database
+
 let connect _ = MySql2.connect
-  ~host:"127.0.0.1"
-  ~port:3306
-  ~user:"root"
+  ~host
+  ~port
+  ~user
+  ~password
+  ~database
   ()

--- a/src/SqlCommonBatchInsert.ml
+++ b/src/SqlCommonBatchInsert.ml
@@ -67,7 +67,12 @@ let insert execute ?batch_size ~table ~columns ~rows user_cb =
     | None -> 1000
     | Some(s) -> s
   in
-  let fail = (fun e -> user_cb (`Error e)) in
+  let fail = (fun err -> rollback ~execute
+    ~fail:(fun err -> user_cb (`Error err))
+    ~ok:(fun _ _ -> user_cb (`Error err))
+    ()
+  )
+  in
   let complete = (fun count id ->
     let ok = (fun _ _ -> user_cb (`Mutation (count, id)))
     in


### PR DESCRIPTION
The batch insert available in `bs-pimp-my-sql` is affected by this bug.

The `mutate_batch` function in `bs-sql-common@2.1.0` only rolls back if there is error when executing the `commit` SQL statement.

This leads to dangling transactions if mysql server sends back an error for one of the batched inserts.

This patch is written against version `2.1.0` but looks like it might apply to `master` as well.

If this is merged and released as a patch release, it should automatically be taken up by projects depending on it via `bs-pimp-my-sql@5.1.1` because the `package.json` for that release depends on version `^2.1.0`.

It's worth noting in case confusion arises that `bs-pimp-my-sql@5.1.1` does not appear to have a commit in its git repo (was it moved to gitlab?)

Thanks!